### PR TITLE
Remove "Escape"  key from editor to don't close application accidentally

### DIFF
--- a/Editor/Source/Editor.cpp
+++ b/Editor/Source/Editor.cpp
@@ -1860,28 +1860,20 @@ namespace Lumos
         if(m_EditorState == EditorState::Play)
             autoSaveTimer = 0.0f;
 
-        if(Input::Get().GetKeyPressed(Lumos::InputCode::Key::Escape))
+        if(Input::Get().GetKeyPressed(Lumos::InputCode::Key::Escape) && GetEditorState() != EditorState::Preview)
         {
-            if(GetEditorState() == EditorState::Preview)
-            {
-                m_CurrentState = AppState::Closing;
-                return;
-            }
-            else
-            {
-                Application::Get().GetSystem<LumosPhysicsEngine>()->SetPaused(true);
-                Application::Get().GetSystem<B2PhysicsEngine>()->SetPaused(true);
+			Application::Get().GetSystem<LumosPhysicsEngine>()->SetPaused(true);
+			Application::Get().GetSystem<B2PhysicsEngine>()->SetPaused(true);
 
-                Application::Get().GetSystem<AudioManager>()->UpdateListener(Application::Get().GetCurrentScene());
-                Application::Get().GetSystem<AudioManager>()->SetPaused(true);
-                Application::Get().SetEditorState(EditorState::Preview);
+			Application::Get().GetSystem<AudioManager>()->UpdateListener(Application::Get().GetCurrentScene());
+			Application::Get().GetSystem<AudioManager>()->SetPaused(true);
+			Application::Get().SetEditorState(EditorState::Preview);
 
-                // m_SelectedEntity = entt::null;
-                m_SelectedEntities.clear();
-                ImGui::SetWindowFocus("###scene");
-                LoadCachedScene();
-                SetEditorState(EditorState::Preview);
-            }
+			// m_SelectedEntity = entt::null;
+			m_SelectedEntities.clear();
+			ImGui::SetWindowFocus("###scene");
+			LoadCachedScene();
+			SetEditorState(EditorState::Preview);
         }
 
         if(m_SceneViewActive)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The user can accidentally closed editor when press "Esc" key multiple times, i removed the key.
