### PR TITLE
 Refactor: `AudioData` Memory Management for Improved RAII Compliance

### DIFF
--- a/Lumos/Source/Lumos/Audio/AudioData.h
+++ b/Lumos/Source/Lumos/Audio/AudioData.h
@@ -4,7 +4,7 @@ namespace Lumos
 {
     struct AudioData
     {
-        unsigned char* Data;
+        std::vector<uint8_t> Data;
         float FreqRate    = 0.0f;
         double Length     = 0.0;
         uint32_t BitRate  = 0;

--- a/Lumos/Source/Lumos/Audio/OggLoader.cpp
+++ b/Lumos/Source/Lumos/Audio/OggLoader.cpp
@@ -39,11 +39,11 @@ namespace Lumos
         data.BitRate                       = 16;
         data.FreqRate                      = static_cast<float>(m_VorbisInfo.sample_rate);
         data.Size                          = stb_vorbis_stream_length_in_samples(m_StreamHandle) * m_VorbisInfo.channels * sizeof(int16_t);
-        data.Data                          = new unsigned char[data.Size];
+        data.Data.resize(data.Size);
 
-        stb_vorbis_get_samples_short_interleaved(m_StreamHandle, m_VorbisInfo.channels, reinterpret_cast<short*>(data.Data), data.Size);
+        stb_vorbis_get_samples_short_interleaved(m_StreamHandle, m_VorbisInfo.channels, reinterpret_cast<short*>(data.Data.data()), data.Size);
 
-        Sound::ConvertToMono(data.Data, data.Size, data.Data, data.Channels, data.BitRate);
+        Sound::ConvertToMono(data.Data.data(), data.Size, data.Data.data(), data.Channels, data.BitRate);
         data.Channels = 1;
         data.Length   = stb_vorbis_stream_length_in_seconds(m_StreamHandle) * 1000.0f; // Milliseconds
 

--- a/Lumos/Source/Lumos/Audio/Sound.cpp
+++ b/Lumos/Source/Lumos/Audio/Sound.cpp
@@ -10,13 +10,8 @@ namespace Lumos
 {
     Sound::Sound()
         : m_Streaming(false)
-        , m_Data(AudioData())
+        , m_Data{}
     {
-    }
-
-    Sound::~Sound()
-    {
-        delete[] m_Data.Data;
     }
 
     SharedPtr<Sound> Sound::Create(const std::string& name, const std::string& extension)

--- a/Lumos/Source/Lumos/Audio/Sound.h
+++ b/Lumos/Source/Lumos/Audio/Sound.h
@@ -11,11 +11,11 @@ namespace Lumos
 
     public:
         static SharedPtr<Sound> Create(const std::string& name, const std::string& extension);
-        virtual ~Sound();
+        virtual ~Sound() = default;
 
-        unsigned char* GetData() const
+        const std::byte* GetData() const
         {
-            return m_Data.Data;
+            return reinterpret_cast<const std::byte*>(m_Data.Data.data());
         }
         int GetBitRate() const
         {

--- a/Lumos/Source/Lumos/Audio/WavLoader.cpp
+++ b/Lumos/Source/Lumos/Audio/WavLoader.cpp
@@ -39,8 +39,8 @@ namespace Lumos
             else if(chunkName == "data")
             {
                 data.Size = chunkSize;
-                data.Data = new unsigned char[data.Size];
-                file.read(reinterpret_cast<char*>(data.Data), chunkSize);
+                data.Data.resize(data.Size);
+                file.read(reinterpret_cast<char*>(data.Data.data()), chunkSize);
                 break;
                 /*
                                 In release mode, ifstream and / or something else were combining

--- a/Lumos/Source/Lumos/Platform/OpenAL/ALSound.cpp
+++ b/Lumos/Source/Lumos/Platform/OpenAL/ALSound.cpp
@@ -16,7 +16,7 @@ namespace Lumos
             m_Data = LoadOgg(fileName);
 
         alGenBuffers(1, &m_Buffer);
-        alBufferData(m_Buffer, GetOALFormat(m_Data.BitRate, m_Data.Channels), m_Data.Data, m_Data.Size, static_cast<ALsizei>(m_Data.FreqRate));
+        alBufferData(m_Buffer, GetOALFormat(m_Data.BitRate, m_Data.Channels), m_Data.Data.data(), m_Data.Size, static_cast<ALsizei>(m_Data.FreqRate));
     }
 
     ALSound::~ALSound()


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
In the existing codebase, the memory allocations for `AudioData` are externally handled. This setup poses the risk of memory leaks, especially when dealing with the external allocation and subsequent release of memory for `AudioData::Data` within the `Sound` destructor. To enhance RAII compliance and mitigate potential memory issues, this pull request proposes a transition to utilizing `std::vector` for managing `AudioData` memory. This adjustment ensures that memory deallocation responsibilities are intrinsic to the `AudioData` class itself, thereby addressing the current shortcomings and promoting a more robust and leak-resistant code structure.

#### Testing
Limited coverage for this PR. Minimal expected impact, seeking guidance from @jmorton06 on implementing appropriate tests.
