### PR TITLE
Made math constants constexpr instead of const

### DIFF
--- a/Lumos/Source/Lumos/Graphics/Material.h
+++ b/Lumos/Source/Lumos/Graphics/Material.h
@@ -155,8 +155,9 @@ namespace Lumos
                 std::string aoFilePath;
                 std::string shaderFilePath;
 
-                static const bool loadOldMaterial = false;
-                if(loadOldMaterial)
+                constexpr bool loadOldMaterial = false;
+
+                if constexpr(loadOldMaterial)
                 {
                     glm::vec4 roughness, metallic, emissive;
                     archive(cereal::make_nvp("Albedo", albedoFilePath),

--- a/Lumos/Source/Lumos/Maths/MathsUtilities.h
+++ b/Lumos/Source/Lumos/Maths/MathsUtilities.h
@@ -27,22 +27,22 @@ namespace Lumos
     namespace Maths
     {
 #undef M_PI
-        static const float M_PI              = 3.14159265358979323846264338327950288f;
-        static const float M_HALF_PI         = M_PI * 0.5f;
-        static const int M_MIN_INT           = 0x80000000;
-        static const int M_MAX_INT           = 0x7fffffff;
-        static const unsigned M_MIN_UNSIGNED = 0x00000000;
-        static const unsigned M_MAX_UNSIGNED = 0xffffffff;
+        static constexpr float M_PI = 3.14159265358979323846264338327950288f;
+        static constexpr float M_HALF_PI = M_PI * 0.5f;
+        static constexpr int M_MIN_INT = 0x80000000;
+        static constexpr int M_MAX_INT = 0x7fffffff;
+        static constexpr unsigned M_MIN_UNSIGNED = 0x00000000;
+        static constexpr unsigned M_MAX_UNSIGNED = 0xffffffff;
 
-        static const float M_EPSILON       = 0.000001f;
-        static const float M_LARGE_EPSILON = 0.00005f;
-        static const float M_MIN_NEARCLIP  = 0.01f;
-        static const float M_MAX_FOV       = 160.0f;
-        static const float M_LARGE_VALUE   = 100000000.0f;
-        static const float M_INFINITY      = (float)HUGE_VAL;
-        static const float M_DEGTORAD      = M_PI / 180.0f;
-        static const float M_DEGTORAD_2    = M_PI / 360.0f; // M_DEGTORAD / 2.f
-        static const float M_RADTODEG      = 1.0f / M_DEGTORAD;
+        static constexpr float M_EPSILON = 0.000001f;
+        static constexpr float M_LARGE_EPSILON = 0.00005f;
+        static constexpr float M_MIN_NEARCLIP = 0.01f;
+        static constexpr float M_MAX_FOV = 160.0f;
+        static constexpr float M_LARGE_VALUE = 100000000.0f;
+        static constexpr float M_INFINITY = std::numeric_limits<float>::infinity();
+        static constexpr float M_DEGTORAD = M_PI / 180.0f;
+        static constexpr float M_DEGTORAD_2 = M_PI / 360.0f; // M_DEGTORAD / 2.f
+        static constexpr float M_RADTODEG = 1.0f / M_DEGTORAD;
 
         template <typename T>
         T Squared(T v)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Math constants are declared using the `const` keyword, but it doesn't guarantee that no memory will be allocated for them. To speed up operations, defining these constants as `constexpr` ensures the fastest possible access to them during runtime.

I also updated `(float)HUGE_VAL` to use `std::numeric_limits<float>::infinity()`, which provides better cross-platform guarantee of its value.