### PR TITLE
Fixed Runtime.xcodeproj path for apple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,21 @@ msbuild /p:Platform=x64 /p:Configuration=Release Lumos.sln
 ```
 cd Lumos
 Tools/premake5 xcode4
-xcodebuild -project Runtime.xcodeproj
+xcodebuild -project Runtime/Runtime.xcodeproj
 ```
 
 M1/M2/M3 Macs may need : 
 ```
 cd Lumos
 Tools/premake5 xcode4 --arch=arm64 --os=macosx
-xcodebuild -project Runtime.xcodeproj
+xcodebuild -project Runtime/Runtime.xcodeproj
 ```
 
 #### iOS
 ```
 cd Lumos
 Tools/premake5 xcode4 --os=ios
-xcodebuild -project Runtime.xcodeproj CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild -project Runtime/Runtime.xcodeproj CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 ```
 
 To run on apple devices with Vulkan ( MoltenVK ), disable Metal API Validation here : Product > Scheme > Edit Scheme… > Run > Options > Metal API Validation


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The project file `Runtime.xcodeproj` does not exist at the root of the repository after running `premake5`, contrary to what the `README.md` file suggests.

#### Proposed Solution
This pull request adds `Runtime/` to the beginning of the `Runtime.xcodeproj` path in the `README.md` sections for Apple targets to accurately reflect the file structure of the project.

#### Additional Notes
We might want to consider updating the `README.md` to include an example of compilation for Apple targets using `Lumos.xcodeproj` instead of `Runtime.xcodeproj` to maintain consistency with Windows and Linux targets.